### PR TITLE
Open functions

### DIFF
--- a/Slog/Classes/Slog.swift
+++ b/Slog/Classes/Slog.swift
@@ -86,23 +86,23 @@ open class Slog {
     }
 
     // MARK: Log Methods
-    public func error<T>(_ object: @autoclosure () -> T, _ fileName: String = #file, _ functionName: String = #function, _ line: Int = #line) {
+    open func error<T>(_ object: @autoclosure () -> T, _ fileName: String = #file, _ functionName: String = #function, _ line: Int = #line) {
         log(object, level:.error, fileName, functionName, line)
     }
 
-    public func warn<T>(_ object: @autoclosure () -> T, _ fileName: String = #file, _ functionName: String = #function, _ line: Int = #line) {
+    open func warn<T>(_ object: @autoclosure () -> T, _ fileName: String = #file, _ functionName: String = #function, _ line: Int = #line) {
         log(object, level:.warn, fileName, functionName, line)
     }
 
-    public func info<T>(_ object: @autoclosure () -> T, _ fileName: String = #file, _ functionName: String = #function, _ line: Int = #line) {
+    open func info<T>(_ object: @autoclosure () -> T, _ fileName: String = #file, _ functionName: String = #function, _ line: Int = #line) {
         log(object, level:.info, fileName, functionName, line)
     }
 
-    public func debug<T>(_ object: @autoclosure () -> T, _ fileName: String = #file, _ functionName: String = #function, _ line: Int = #line) {
+    open func debug<T>(_ object: @autoclosure () -> T, _ fileName: String = #file, _ functionName: String = #function, _ line: Int = #line) {
         log(object, level:.debug, fileName, functionName, line)
     }
 
-    public func verbose<T>(_ object: @autoclosure () -> T, _ fileName: String = #file, _ functionName: String = #function, _ line: Int = #line) {
+    open func verbose<T>(_ object: @autoclosure () -> T, _ fileName: String = #file, _ functionName: String = #function, _ line: Int = #line) {
         log(object, level:.verbose, fileName, functionName, line)
     }
 

--- a/Slog/Classes/Slog.swift
+++ b/Slog/Classes/Slog.swift
@@ -49,13 +49,14 @@ open class Slog {
     /// If true, prints emojis to signify log type, defaults to true
     public var useEmoji: Bool = true
 
-    // MARK: Private
     /// Date formatter for log
-    fileprivate let dateformatter: DateFormatter = {
+    public var dateFormatter: DateFormatter = {
         let df = DateFormatter()
         df.dateFormat = "Y-MM-dd H:m:ss.SSS"
         return df
     }()
+
+    // MARK: Private
 
     /// The name of the log, used to differentiate multiple logs, if not initialized it is set to "".
     fileprivate let name: String
@@ -108,7 +109,7 @@ open class Slog {
     /// Generic log method
     fileprivate func log<T>(_ object: @autoclosure () -> T, level: Slog.Level, _ fileName: String, _ functionName: String, _ line: Int) {
         if logLevel.rawValue <= level.rawValue {
-            let date = dateformatter.string(from: Date())
+            let date = dateFormatter.string(from: Date())
             let components: [String] = fileName.components(separatedBy: "/")
             let objectName = components.last ?? "Unknown Object"
             var levelString = useEmoji ? level.emoji : "|" + level.name.uppercased() + "|"


### PR DESCRIPTION
- Exposed `dateFormatter` property as public, to allow for log timestamp customization
- Exposed logging functions as `open` instead of just `public`. The class itself was already `open`, but nothing was overridable. An example use case for subclassing `Slog` is if you want to maintain original logging behavior, but also forward `error` (or `warn` etc.) messages to an analytics platform.